### PR TITLE
Added option to return buffer

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,6 +35,9 @@ ex:
   { name: 'gallery', maxCount: 8 }
 ]
 ```
+
+The "storage" section dictates how the files are saved and what data that will be returned. "Disk" will return a path to the file and "Memory" will return a buffer. For more information on limitations involved with the different storage options please refer to the Multer documentation.
+
 #### Example
 With HTML like the following:
 ```html

--- a/httpInMultipart.html
+++ b/httpInMultipart.html
@@ -34,6 +34,13 @@
         <label for="node-input-fields"><i class="fa fa-wpforms"></i> <span data-i18n="httpInMultipart.label.fields">Fields</span></label>
         <input type="text" id="node-input-fields" placeholder='[ {"name": "field1", "maxCount": 8}]'>
     </div>
+    <div class="form-row">
+        <label for="node-input-storage"><i class="fa fa-tasks"></i> <span data-i18n="httpInMultipart.label.storage">Storage</span></label>
+        <select type="text" id="node-input-storage" style="width:72%;">
+        <option value="disk">Disk</option>
+        <option value="memory">Memory</option>
+        </select>
+    </div>
     <div class="form-row row-swagger-doc">
         <label for="node-input-swaggerDoc"><i class="fa fa-file-text-o"></i> <span data-i18n="httpInMultipart.label.doc">Swagger Docs</span></label>
         <input type="text" id="node-input-swaggerDoc">
@@ -52,6 +59,9 @@
     <p>
         The "fields" section contains an array of key / value pairs which with the following format:
         <pre>[{ "name": "<field name>"}]</pre>
+    </p>
+    <p>
+        The "storage" section dictates how the files are saved and what data that will be returned. "Disk" will return a path to the file and "Memory" will return a buffer.
     </p>
     <p>
         You can also pass in an optional "maxCount" value can be passed in as well.  This limits the number
@@ -80,6 +90,7 @@
             url: {value:"",required:true},
             method: {value:"post",required:true},
             fields: {value: "", required: true},
+            storage: {value: "disk", required: true},
             swaggerDoc: {type:"swagger-doc", required:false}
         },
         inputs:0,

--- a/httpInMultipart.js
+++ b/httpInMultipart.js
@@ -29,8 +29,10 @@ module.exports = function(RED) {
     var typer = require('media-typer');
     // Use multer for parsing multi-part forms with fil
     var multer = require('multer');
+    var storage = multer.memoryStorage();
     var upload = multer({
-        "dest": "/tmp"
+        "dest": "/tmp",
+        "storage": storage
     });
     var isUtf8 = require('is-utf8');
     var formidable = require('formidable');

--- a/httpInMultipart.js
+++ b/httpInMultipart.js
@@ -29,11 +29,6 @@ module.exports = function(RED) {
     var typer = require('media-typer');
     // Use multer for parsing multi-part forms with fil
     var multer = require('multer');
-    var storage = multer.memoryStorage();
-    var upload = multer({
-        "dest": "/tmp",
-        "storage": storage
-    });
     var isUtf8 = require('is-utf8');
     var formidable = require('formidable');
     
@@ -152,6 +147,7 @@ module.exports = function(RED) {
             this.method = n.method;
             this.swaggerDoc = n.swaggerDoc;
             this.fields = n.fields;
+            this.storage = n.storage;
             var node = this;
             
             this.rawBodyParser = function(req, res, next) {
@@ -182,6 +178,19 @@ module.exports = function(RED) {
                     
                     if (isMultiPart) {
                         var fields = JSON.parse(node.fields);
+
+                        if (node.storage === "disk") {
+                            var upload = multer({
+                                "dest": "/tmp"
+                            });
+                        } else {
+                            var storage = multer.memoryStorage();
+
+                            var upload = multer({
+                                "storage": storage
+                            });
+                        }
+
                         upload.fields(fields)(req, res, function (err) {
                             if (err) {
                                 next(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-http-multipart",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A node-red node for providing multi-part form support for the standard node-red HTTP node.",
   "keywords": [
     "node-red",


### PR DESCRIPTION
I added the option to choose how the files should be stored. The reason for adding this was that I needed to get the buffer of a file and after looking into the documentation of Multer I found that setting the storage to memory presented me with the file buffer instead of the path.

This was also discussed in #2 