### PR TITLE
enable to change dir to save file

### DIFF
--- a/httpInMultipart.html
+++ b/httpInMultipart.html
@@ -34,6 +34,10 @@
         <label for="node-input-fields"><i class="fa fa-wpforms"></i> <span data-i18n="httpInMultipart.label.fields">Fields</span></label>
         <input type="text" id="node-input-fields" placeholder='[ {"name": "field1", "maxCount": 8}]'>
     </div>
+    <div class="form-row">
+        <label for="node-input-fileDest"><i class="fa fa-folder"></i> <span data-i18n="httpInMultipart.label.fileDest">File Dest</span></label>
+        <input type="text" id="node-input-fileDest" placeholder='/tmp'>
+    </div>
     <div class="form-row row-swagger-doc">
         <label for="node-input-swaggerDoc"><i class="fa fa-file-text-o"></i> <span data-i18n="httpInMultipart.label.doc">Swagger Docs</span></label>
         <input type="text" id="node-input-swaggerDoc">
@@ -80,6 +84,7 @@
             url: {value:"",required:true},
             method: {value:"post",required:true},
             fields: {value: "", required: true},
+            fileDest: {value: "/tmp", required: true},
             swaggerDoc: {type:"swagger-doc", required:false}
         },
         inputs:0,

--- a/httpInMultipart.js
+++ b/httpInMultipart.js
@@ -40,9 +40,6 @@ module.exports = function(RED) {
     var typer = require('media-typer');
     // Use multer for parsing multi-part forms with fil
     var multer = require('multer');
-    var upload = multer({
-        "dest": "/tmp"
-    });
     var isUtf8 = require('is-utf8');
     var formidable = require('formidable');
     
@@ -161,6 +158,7 @@ module.exports = function(RED) {
             this.method = n.method;
             this.swaggerDoc = n.swaggerDoc;
             this.fields = n.fields;
+            this.fileDest = n.fileDest;
             var node = this;
             
             this.rawBodyParser = function(req, res, next) {
@@ -191,6 +189,9 @@ module.exports = function(RED) {
                     
                     if (isMultiPart) {
                         var fields = JSON.parse(node.fields);
+                        var upload = multer({
+                            "dest": node.fileDest
+                        });
                         upload.fields(fields)(req, res, function (err) {
                             if (err) {
                                 next(err);


### PR DESCRIPTION
Currently, the files from a request are saved under /tmp directory.
The directory path is hard-coded.

However, in some  environments, the users can't access to /tmp.

Therefore, I enable node users to change the directory to save uploaded files 
from the node properties in the UI.
